### PR TITLE
Refactoring pvt activity

### DIFF
--- a/AndroidPvtLib/build.gradle.kts
+++ b/AndroidPvtLib/build.gradle.kts
@@ -53,4 +53,5 @@ dependencies {
     androidTestImplementation("androidx.test.espresso:espresso-core:3.3.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9")
     implementation("com.google.code.gson:gson:2.8.6")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.0")
 }

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/Pvt.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/Pvt.kt
@@ -294,7 +294,7 @@ internal class Pvt(private val args: Args = Args.default()) {
 
     private companion object {
         private const val TAG = "PVT"
-        private const val LOG_STATE_TRANSITIONS: Boolean = true
+        private const val LOG_STATE_TRANSITIONS: Boolean = false
         private val INIT_STATE = Instructions()
     }
 

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/Pvt.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/Pvt.kt
@@ -8,7 +8,15 @@ import kotlinx.coroutines.Dispatchers.Main
 import java.lang.IllegalStateException
 import kotlin.properties.Delegates
 
-internal class Pvt(private val args: Args = Args.default()) {
+internal const val ONE_SECOND: Long = 1000
+internal const val DEFAULT_STIMULUS_COUNT = 3
+internal const val DEFAULT_MIN_INTERVAL = 2 * ONE_SECOND
+internal const val DEFAULT_MAX_INTERVAL = 4 * ONE_SECOND
+internal const val DEFAULT_COUNTDOWN_TIME = 3 * ONE_SECOND
+internal const val DEFAULT_STIMULUS_TIMEOUT = 10 * ONE_SECOND
+internal const val DEFAULT_POST_RESPONSE_DELAY = 2 * ONE_SECOND
+
+internal class Pvt(private val args: PvtArgs = PvtArgs.default()) {
 
     private var remainingTestCount = args.stimulusCount
     private var listener: PvtListener? = null
@@ -303,16 +311,8 @@ internal class Pvt(private val args: Args = Args.default()) {
 
     private companion object {
         private const val TAG = "PVT"
-        private const val ONE_SECOND: Long = 1000
         private const val LOG_STATE_TRANSITIONS: Boolean = false
         private val INIT_STATE = Instructions()
-
-        private const val DEFAULT_STIMULUS_COUNT = 3
-        private const val DEFAULT_MIN_INTERVAL = 2 * ONE_SECOND
-        private const val DEFAULT_MAX_INTERVAL = 4 * ONE_SECOND
-        private const val DEFAULT_COUNTDOWN_TIME = 3 * ONE_SECOND
-        private const val DEFAULT_STIMULUS_TIMEOUT = 10 * ONE_SECOND
-        private const val DEFAULT_POST_RESPONSE_DELAY = 2 * ONE_SECOND
     }
 
     internal data class Result(
@@ -321,42 +321,4 @@ internal class Pvt(private val args: Args = Args.default()) {
         val interval: Long,
         val reactionDelay: Long
         )
-
-    internal data class Args(
-        var stimulusCount: Int = DEFAULT_STIMULUS_COUNT,
-        var minInterval: Long = DEFAULT_MIN_INTERVAL,
-        var maxInterval: Long = DEFAULT_MAX_INTERVAL,
-        var countDownTime: Long = DEFAULT_COUNTDOWN_TIME,
-        var stimulusTimeout: Long = DEFAULT_STIMULUS_TIMEOUT,
-        var postResponseDelay: Long = DEFAULT_POST_RESPONSE_DELAY,
-    ) {
-        constructor(
-            stimulusCount: Int? = null,
-            minInterval: Long? = null,
-            maxInterval: Long? = null,
-            countDownTime: Long? = null,
-            stimulusTimeout: Long? = null,
-            postResponseDelay: Long? = null
-        ) : this(
-            stimulusCount ?: DEFAULT_STIMULUS_COUNT,
-            minInterval ?: DEFAULT_MIN_INTERVAL,
-            maxInterval ?: DEFAULT_MAX_INTERVAL,
-            countDownTime ?: DEFAULT_COUNTDOWN_TIME,
-            stimulusTimeout ?: DEFAULT_STIMULUS_TIMEOUT,
-            postResponseDelay ?: DEFAULT_POST_RESPONSE_DELAY
-        )
-
-        companion object {
-            fun default(): Args {
-                return Args(
-                    DEFAULT_STIMULUS_COUNT,
-                    DEFAULT_MIN_INTERVAL,
-                    DEFAULT_MAX_INTERVAL,
-                    DEFAULT_COUNTDOWN_TIME,
-                    DEFAULT_STIMULUS_TIMEOUT,
-                    DEFAULT_POST_RESPONSE_DELAY
-                )
-            }
-        }
-    }
 }

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/Pvt.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/Pvt.kt
@@ -30,8 +30,8 @@ internal class Pvt(private val args: Args = Args.default()) {
     private var curState by Delegates.observable<State>(INIT_STATE, {
             _, oldState, newState -> if (LOG_STATE_TRANSITIONS) {
             Log.d(TAG, "transition ($oldState -> $newState)")
-            notifyStateChange(newState)
         }
+        notifyStateChange(newState)
     })
 
     fun handleActionDownTouchEvent() {

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/Pvt.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/Pvt.kt
@@ -18,9 +18,12 @@ internal const val DEFAULT_POST_RESPONSE_DELAY = 2 * ONE_SECOND
 
 internal class Pvt(private val args: Args = Args.default()) {
 
-    private var remainingTestCount = args.stimulusCount
     private var listener: Listener? = null
     private var stimulusListener: StimulusListener? = null
+    // Stimulus listener is used to shortcut the view model
+    // to improve performance showing the stimulus to the user
+
+    private var remainingTestCount = args.stimulusCount
     private var curJob: Job? = null
     private val results: MutableList<Result> = mutableListOf()
 
@@ -87,7 +90,6 @@ internal class Pvt(private val args: Args = Args.default()) {
             withContext(Main) {
                 stimulusListener?.onStimulus()
             }
-
             val result = runStimulus(System.currentTimeMillis(), intervalDelay)
 
             results.addSafe(result)
@@ -118,7 +120,6 @@ internal class Pvt(private val args: Args = Args.default()) {
 
     private suspend fun runInterval(delay: Long) {
         curState = curState.consumeAction(Action.StartInterval)
-
         delay(delay)
     }
 

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/Pvt.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/Pvt.kt
@@ -16,7 +16,7 @@ internal const val DEFAULT_COUNTDOWN_TIME = 3 * ONE_SECOND
 internal const val DEFAULT_STIMULUS_TIMEOUT = 10 * ONE_SECOND
 internal const val DEFAULT_POST_RESPONSE_DELAY = 2 * ONE_SECOND
 
-internal class Pvt(private val args: PvtArgs = PvtArgs.default()) {
+internal class Pvt(private val args: Args = Args.default()) {
 
     private var remainingTestCount = args.stimulusCount
     private var listener: PvtListener? = null
@@ -314,11 +314,4 @@ internal class Pvt(private val args: PvtArgs = PvtArgs.default()) {
         private const val LOG_STATE_TRANSITIONS: Boolean = false
         private val INIT_STATE = Instructions()
     }
-
-    internal data class Result(
-        val testNumber: Int,
-        val timestamp: Long,
-        val interval: Long,
-        val reactionDelay: Long
-        )
 }

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/Pvt.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/Pvt.kt
@@ -268,14 +268,14 @@ internal class Pvt(private val args: Args = Args.default()) {
         fun consumeAction(action: Action): State
     }
 
-    interface Listener {
+    internal interface Listener {
         fun onStateUpdate(newState: State) = Unit
         fun onCountdownUpdate(millisElapsed: Long) = Unit
         fun onReactionDelayUpdate(millisElapsed: Long) = Unit
         fun onCompleteTest(jsonResults: String) = Unit
     }
 
-    interface StimulusListener {
+    internal interface StimulusListener {
         fun onStimulus() = Unit
     }
 

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/Pvt.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/Pvt.kt
@@ -15,8 +15,6 @@ internal class Pvt(
     private val countDownTime: Long = 3 * ONE_SECOND,
     private val stimulusTimeout: Long = 10 * ONE_SECOND,
     private val postResponseDelay: Long = 2 * ONE_SECOND,
-    private val postCompletionDelay: Long = 2 * ONE_SECOND,
-    private val logStateTransitions: Boolean = false
 ) {
 
     private var remainingTestCount = stimulusCount
@@ -25,7 +23,7 @@ internal class Pvt(
     private val results: MutableList<PvtResult> = mutableListOf()
 
     private var curState by Delegates.observable<PvtState>(INIT_STATE, {
-            _, oldState, newState -> if (logStateTransitions) {
+            _, oldState, newState -> if (LOG_STATE_TRANSITIONS) {
             Log.d(TAG, "transition ($oldState -> $newState)")
         }
     })
@@ -164,7 +162,8 @@ internal class Pvt(
         curState = curState.consumeAction(Action.Complete)
         withContext(Main) { listener?.onCompleteTest() }
 
-        delay(postCompletionDelay)
+        delay(postResponseDelay)
+
         withContext(Main) {
             listener?.onResults(results.toJson())
         }
@@ -316,6 +315,7 @@ internal class Pvt(
     companion object {
         private const val TAG = "PVT"
         private const val ONE_SECOND: Long = 1000
+        private const val LOG_STATE_TRANSITIONS: Boolean = false
         private val INIT_STATE = Instructions()
     }
 

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtActivity.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtActivity.kt
@@ -76,6 +76,7 @@ class PvtActivity : AppCompatActivity(), Pvt.StimulusListener {
         super.onTouchEvent(event)
 
         if (event?.action == MotionEvent.ACTION_DOWN) {
+            // Shortcutting the viewmodel, directly sending touch event to pvt
             viewModel.pvt.handleActionDownTouchEvent()
         }
 

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtActivity.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtActivity.kt
@@ -103,9 +103,10 @@ class PvtActivity : AppCompatActivity(), Pvt.StimulusListener {
     private fun displayCountdown() {
         binding.viewStimulus.visibility = View.GONE
 
-        binding.textViewSub.visibility = View.VISIBLE
         binding.textViewMain.text = getString(R.string.ready_message)
         binding.textViewMain.visibility = View.VISIBLE
+
+        binding.textViewSub.visibility = View.VISIBLE
     }
 
     private fun displayInterval() {

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtActivity.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtActivity.kt
@@ -7,12 +7,22 @@ import android.os.Bundle
 import android.util.Log
 import android.view.MotionEvent
 import android.view.View
+import androidx.lifecycle.ViewModelProvider
 import rs.arthu.androidpvt.lib.databinding.ActivityPvtBinding
+
+const val PVT_RESULTS_KEY = "pvtResultsKey"
+internal const val STIMULUS_COUNT = "stimulusCount"
+internal const val MIN_INTERVAL = "minInterval"
+internal const val MAX_INTERVAL = "maxInterval"
+internal const val COUNTDOWN_TIME = "countdownTime"
+internal const val STIMULUS_TIMEOUT = "stimulusTimeout"
+internal const val POST_RESPONSE_DELAY = "postResponseDelay"
 
 class PvtActivity : AppCompatActivity() {
 
-    private var pvt: Pvt? = null
     private lateinit var binding: ActivityPvtBinding
+    private lateinit var viewModel: PvtViewModel
+    private lateinit var viewModelFactory: PvtViewModelFactory
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -22,65 +32,17 @@ class PvtActivity : AppCompatActivity() {
         setContentView(view)
 
         val intentExtras = intent.extras
-        val pvtArgs = getPvtArgsFromIntentExtras(intentExtras)
+        val pvtArgs = PvtArgs.fromBundle(intentExtras)
 
-        Log.d(TAG, "args: $pvtArgs")
+        viewModelFactory = PvtViewModelFactory(pvtArgs)
+        viewModel = ViewModelProvider(this, viewModelFactory).get(PvtViewModel::class.java)
 
-        pvt = Pvt(pvtArgs)
-
-        pvt?.setListener(
-            onStartCountdown = {
-                binding.textViewCountdown.visibility = View.VISIBLE
-                binding.textViewMessage.text = getString(R.string.ready_message)
-                binding.textViewMessage.visibility = View.VISIBLE
-                binding.viewStimulus.visibility = View.GONE
-            },
-            onCountdownUpdate = { updateCountdown(it) },
-            onFinishCountdown = {
-                binding.textViewCountdown.visibility = View.GONE
-                binding.textViewMessage.visibility = View.GONE
-                binding.textViewMessage.text = ""
-            },
-            onIntervalShowing = {
-                binding.textViewMessage.text = ""
-                binding.textViewMessage.visibility = View.GONE
-            },
-            onStimulusShowing = {
-                binding.viewStimulus.visibility = View.VISIBLE
-                binding.textViewMessage.visibility = View.VISIBLE
-            },
-            onStimulusHidden = {
-                binding.viewStimulus.visibility = View.GONE
-                binding.textViewMessage.visibility = View.GONE
-            },
-            onReactionDelayUpdate = {
-                updateReactionDelay(it)
-            },
-            onInvalidReaction = {
-                binding.textViewMessage.text = getString(R.string.invalid_reaction)
-                binding.textViewMessage.visibility = View.VISIBLE
-            },
-            onCompleteTest = {
-                binding.textViewMessage.visibility = View.VISIBLE
-                binding.textViewMessage.text = getString(R.string.test_complete)
-            },
-            onResults = {
-                val returnIntent = Intent()
-                returnIntent.putExtra(PVT_RESULTS_KEY, it)
-                setResult(RESULT_OK, returnIntent)
-                finish()
-            },
-        )
     }
 
     override fun onTouchEvent(event: MotionEvent?): Boolean {
         super.onTouchEvent(event)
 
-        if (event?.action == MotionEvent.ACTION_DOWN) {
-            pvt?.handleActionDownTouchEvent()
-        }
-
-        return true
+        return viewModel.handleOnTouchEvent(event)
     }
 
     private fun updateCountdown(millisElapsed: Long) {
@@ -89,52 +51,6 @@ class PvtActivity : AppCompatActivity() {
 
     private fun updateReactionDelay(millisElapsed: Long) {
         binding.textViewMessage.text = getString(R.string.reaction_delay, millisElapsed)
-    }
-
-    private fun getPvtArgsFromIntentExtras(bundle: Bundle?): Pvt.Args {
-        if (bundle == null) return Pvt.Args.default()
-
-        val keySet = bundle.keySet()
-
-        var stimulusCount: Int? = null
-        var minInterval: Long? = null
-        var maxInterval: Long? = null
-        var countDownTime: Long? = null
-        var stimulusTimeout: Long? = null
-        var postResponseDelay: Long? = null
-
-        if (keySet.contains(STIMULUS_COUNT)) {
-            stimulusCount = bundle.getInt(STIMULUS_COUNT)
-        }
-
-        if (keySet.contains(MIN_INTERVAL)) {
-            minInterval = bundle.getLong(MIN_INTERVAL)
-        }
-
-        if (keySet.contains(MAX_INTERVAL)) {
-            maxInterval = bundle.getLong(MAX_INTERVAL)
-        }
-
-        if (keySet.contains(COUNTDOWN_TIME)) {
-            countDownTime = bundle.getLong(COUNTDOWN_TIME)
-        }
-
-        if (keySet.contains(STIMULUS_TIMEOUT)) {
-            stimulusTimeout = bundle.getLong(STIMULUS_TIMEOUT)
-        }
-
-        if (keySet.contains(POST_RESPONSE_DELAY)) {
-            postResponseDelay = bundle.getLong(POST_RESPONSE_DELAY)
-        }
-
-        return Pvt.Args(
-            stimulusCount, minInterval, maxInterval, countDownTime, stimulusTimeout, postResponseDelay
-        )
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        pvt?.cancel()
     }
 
     class Builder {
@@ -204,12 +120,5 @@ class PvtActivity : AppCompatActivity() {
 
     companion object {
         private const val TAG = "PvtNew"
-        const val PVT_RESULTS_KEY = "pvtResultsKey"
-        const val STIMULUS_COUNT = "stimulusCount"
-        const val MIN_INTERVAL = "minInterval"
-        const val MAX_INTERVAL = "maxInterval"
-        const val COUNTDOWN_TIME = "countdownTime"
-        const val STIMULUS_TIMEOUT = "stimulusTimeout"
-        const val POST_RESPONSE_DELAY = "postResponseDelay"
     }
 }

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtActivity.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtActivity.kt
@@ -4,9 +4,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import android.util.Log
 import android.view.MotionEvent
-import android.view.View
 import androidx.lifecycle.ViewModelProvider
 import rs.arthu.androidpvt.lib.databinding.ActivityPvtBinding
 
@@ -31,12 +29,15 @@ class PvtActivity : AppCompatActivity() {
         val view = binding.root
         setContentView(view)
 
+        initViewModel()
+    }
+
+    private fun initViewModel() {
         val intentExtras = intent.extras
         val pvtArgs = Args.fromBundle(intentExtras)
 
         viewModelFactory = PvtViewModelFactory(pvtArgs)
         viewModel = ViewModelProvider(this, viewModelFactory).get(PvtViewModel::class.java)
-
     }
 
     override fun onTouchEvent(event: MotionEvent?): Boolean {
@@ -45,12 +46,12 @@ class PvtActivity : AppCompatActivity() {
         return viewModel.handleOnTouchEvent(event)
     }
 
-    private fun updateCountdown(millisElapsed: Long) {
-        binding.textViewCountdown.text = (millisElapsed / 1000).toString()
+    private fun updateCountdown(millisElapsed: String) {
+        binding.textViewSub.text = millisElapsed
     }
 
-    private fun updateReactionDelay(millisElapsed: Long) {
-        binding.textViewMessage.text = getString(R.string.reaction_delay, millisElapsed)
+    private fun updateReactionDelay(millisElapsed: String) {
+        binding.textViewMain.text = getString(R.string.reaction_delay, millisElapsed)
     }
 
     class Builder {
@@ -66,9 +67,9 @@ class PvtActivity : AppCompatActivity() {
             return this
         }
 
-        fun withInterval(minInterval: Long, maxInterval: Long): Builder {
-            this.minInterval = minInterval
-            this.maxInterval = maxInterval
+        fun withInterval(min: Long, max: Long): Builder {
+            this.minInterval = min
+            this.maxInterval = max
             return this
         }
 
@@ -116,9 +117,5 @@ class PvtActivity : AppCompatActivity() {
 
             return intent
         }
-    }
-
-    companion object {
-        private const val TAG = "PvtNew"
     }
 }

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtActivity.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtActivity.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import android.util.Log
 import android.view.MotionEvent
 import android.view.View
 import androidx.lifecycle.Observer
@@ -63,7 +62,9 @@ class PvtActivity : AppCompatActivity(), Pvt.StimulusListener {
             is Pvt.Instructions -> displayInstructions()
             is Pvt.Countdown -> displayCountdown()
             is Pvt.Interval -> displayInterval()
-            is Pvt.StimulusShowing -> {}
+            is Pvt.StimulusShowing -> {} // Stimulus listener handles
+            // state change here, otherwise time taken to show stimulus
+            // affects result significantly
             is Pvt.InvalidReaction -> displayInvalidReaction()
             is Pvt.ValidReaction -> {}
             is Pvt.Complete -> displayComplete()
@@ -90,7 +91,13 @@ class PvtActivity : AppCompatActivity(), Pvt.StimulusListener {
     }
 
     private fun displayInstructions() {
-        Log.d("MainActivity", "Instructions")
+        binding.viewStimulus.visibility = View.GONE
+
+        binding.textViewMain.visibility = View.VISIBLE
+        binding.textViewMain.text = getString(R.string.instructions)
+
+        binding.textViewSub.visibility = View.GONE
+        binding.textViewSub.text = ""
     }
 
     private fun displayCountdown() {

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtActivity.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtActivity.kt
@@ -22,7 +22,8 @@ class PvtActivity : AppCompatActivity() {
         val numberOfStimulus =
             intent.getIntExtra(NUMBER_OF_STIMULUS_KEY, DEFAULT_NUMBER_OF_STIMULUS)
 
-        pvt = Pvt(numberOfStimulus)
+        pvt = Pvt(stimulusCount = numberOfStimulus)
+
         pvt?.setListener(
             onStartCountdown = {
                 binding.textViewCountdown.visibility = View.VISIBLE

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtActivity.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtActivity.kt
@@ -21,12 +21,12 @@ class PvtActivity : AppCompatActivity() {
         val view = binding.root
         setContentView(view)
 
+        val intentExtras = intent.extras
+        val pvtArgs = getPvtArgsFromIntentExtras(intentExtras)
 
-        val numberOfStimulus =
-            intent.getIntExtra(STIMULUS_COUNT)
-        Log.d(TAG, "Intent: $numberOfStimulus")
+        Log.d(TAG, "args: $pvtArgs")
 
-        pvt = Pvt(stimulusCount = numberOfStimulus)
+        pvt = Pvt(pvtArgs)
 
         pvt?.setListener(
             onStartCountdown = {
@@ -89,6 +89,47 @@ class PvtActivity : AppCompatActivity() {
 
     private fun updateReactionDelay(millisElapsed: Long) {
         binding.textViewMessage.text = getString(R.string.reaction_delay, millisElapsed)
+    }
+
+    private fun getPvtArgsFromIntentExtras(bundle: Bundle?): Pvt.Args {
+        if (bundle == null) return Pvt.Args.default()
+
+        val keySet = bundle.keySet()
+
+        var stimulusCount: Int? = null
+        var minInterval: Long? = null
+        var maxInterval: Long? = null
+        var countDownTime: Long? = null
+        var stimulusTimeout: Long? = null
+        var postResponseDelay: Long? = null
+
+        if (keySet.contains(STIMULUS_COUNT)) {
+            stimulusCount = bundle.getInt(STIMULUS_COUNT)
+        }
+
+        if (keySet.contains(MIN_INTERVAL)) {
+            minInterval = bundle.getLong(MIN_INTERVAL)
+        }
+
+        if (keySet.contains(MAX_INTERVAL)) {
+            maxInterval = bundle.getLong(MAX_INTERVAL)
+        }
+
+        if (keySet.contains(COUNTDOWN_TIME)) {
+            countDownTime = bundle.getLong(COUNTDOWN_TIME)
+        }
+
+        if (keySet.contains(STIMULUS_TIMEOUT)) {
+            stimulusTimeout = bundle.getLong(STIMULUS_TIMEOUT)
+        }
+
+        if (keySet.contains(POST_RESPONSE_DELAY)) {
+            postResponseDelay = bundle.getLong(POST_RESPONSE_DELAY)
+        }
+
+        return Pvt.Args(
+            stimulusCount, minInterval, maxInterval, countDownTime, stimulusTimeout, postResponseDelay
+        )
     }
 
     override fun onDestroy() {
@@ -170,6 +211,5 @@ class PvtActivity : AppCompatActivity() {
         const val COUNTDOWN_TIME = "countdownTime"
         const val STIMULUS_TIMEOUT = "stimulusTimeout"
         const val POST_RESPONSE_DELAY = "postResponseDelay"
-        const val DEFAULT_NUMBER_OF_STIMULUS = 3
     }
 }

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtActivity.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtActivity.kt
@@ -1,8 +1,10 @@
 package rs.arthu.androidpvt.lib
 
+import android.content.Context
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.util.Log
 import android.view.MotionEvent
 import android.view.View
 import rs.arthu.androidpvt.lib.databinding.ActivityPvtBinding
@@ -19,8 +21,10 @@ class PvtActivity : AppCompatActivity() {
         val view = binding.root
         setContentView(view)
 
+
         val numberOfStimulus =
-            intent.getIntExtra(NUMBER_OF_STIMULUS_KEY, DEFAULT_NUMBER_OF_STIMULUS)
+            intent.getIntExtra(STIMULUS_COUNT)
+        Log.d(TAG, "Intent: $numberOfStimulus")
 
         pvt = Pvt(stimulusCount = numberOfStimulus)
 
@@ -92,10 +96,80 @@ class PvtActivity : AppCompatActivity() {
         pvt?.cancel()
     }
 
+    class Builder {
+        private var stimulusCount: Int? = null
+        private var minInterval: Long? = null
+        private var maxInterval: Long? = null
+        private var countDownTime: Long? = null
+        private var stimulusTimeout: Long? = null
+        private var postResponseDelay: Long? = null
+
+        fun withStimulusCount(count: Int): Builder {
+            this.stimulusCount = count
+            return this
+        }
+
+        fun withInterval(minInterval: Long, maxInterval: Long): Builder {
+            this.minInterval = minInterval
+            this.maxInterval = maxInterval
+            return this
+        }
+
+        fun withCountdownTime(time: Long): Builder {
+            this.countDownTime = time
+            return this
+        }
+
+        fun withStimulusTimeout(timeout: Long): Builder {
+            this.stimulusTimeout = timeout
+            return this
+        }
+
+        fun withPostResponseDelay(delay: Long): Builder {
+            this.postResponseDelay = delay
+            return this
+        }
+
+        fun build(context: Context): Intent {
+            val intent = Intent(context, PvtActivity::class.java)
+
+            stimulusCount?.let {
+                intent.putExtra(STIMULUS_COUNT, it)
+            }
+
+            minInterval?.let {
+                intent.putExtra(MIN_INTERVAL, it)
+            }
+
+            maxInterval?.let {
+                intent.putExtra(MAX_INTERVAL, it)
+            }
+
+            countDownTime?.let {
+                intent.putExtra(COUNTDOWN_TIME, it)
+            }
+
+            stimulusTimeout?.let {
+                intent.putExtra(STIMULUS_TIMEOUT, it)
+            }
+
+            postResponseDelay?.let {
+                intent.putExtra(POST_RESPONSE_DELAY, it)
+            }
+
+            return intent
+        }
+    }
+
     companion object {
         private const val TAG = "PvtNew"
         const val PVT_RESULTS_KEY = "pvtResultsKey"
-        const val NUMBER_OF_STIMULUS_KEY = "numberOfStimulus"
+        const val STIMULUS_COUNT = "stimulusCount"
+        const val MIN_INTERVAL = "minInterval"
+        const val MAX_INTERVAL = "maxInterval"
+        const val COUNTDOWN_TIME = "countdownTime"
+        const val STIMULUS_TIMEOUT = "stimulusTimeout"
+        const val POST_RESPONSE_DELAY = "postResponseDelay"
         const val DEFAULT_NUMBER_OF_STIMULUS = 3
     }
 }

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtActivity.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtActivity.kt
@@ -32,7 +32,7 @@ class PvtActivity : AppCompatActivity() {
         setContentView(view)
 
         val intentExtras = intent.extras
-        val pvtArgs = PvtArgs.fromBundle(intentExtras)
+        val pvtArgs = Args.fromBundle(intentExtras)
 
         viewModelFactory = PvtViewModelFactory(pvtArgs)
         viewModel = ViewModelProvider(this, viewModelFactory).get(PvtViewModel::class.java)

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtActivity.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtActivity.kt
@@ -52,7 +52,6 @@ class PvtActivity : AppCompatActivity(), Pvt.StimulusListener {
         })
 
         viewModel.results.observe(this, {
-            Log.d("MainActivity", it)
             returnResults(it)
         })
 
@@ -83,7 +82,6 @@ class PvtActivity : AppCompatActivity(), Pvt.StimulusListener {
     }
 
     private fun updateCountdown(millisElapsed: String) {
-        Log.d("MainActivity", millisElapsed)
         binding.textViewSub.text = millisElapsed
     }
 
@@ -114,7 +112,6 @@ class PvtActivity : AppCompatActivity(), Pvt.StimulusListener {
     }
 
     override fun onStimulus() {
-        Log.d("MainActivity", "onStimulus")
         binding.viewStimulus.visibility = View.VISIBLE
         binding.textViewMain.visibility = View.VISIBLE
     }

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtArgs.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtArgs.kt
@@ -2,7 +2,7 @@ package rs.arthu.androidpvt.lib
 
 import android.os.Bundle
 
-internal class PvtArgs(
+internal class Args(
     var stimulusCount: Int = DEFAULT_STIMULUS_COUNT,
     var minInterval: Long = DEFAULT_MIN_INTERVAL,
     var maxInterval: Long = DEFAULT_MAX_INTERVAL,
@@ -28,8 +28,8 @@ internal class PvtArgs(
     )
 
     companion object {
-        fun default(): PvtArgs {
-            return PvtArgs(
+        fun default(): Args {
+            return Args(
                     DEFAULT_STIMULUS_COUNT,
                     DEFAULT_MIN_INTERVAL,
                     DEFAULT_MAX_INTERVAL,
@@ -39,7 +39,7 @@ internal class PvtArgs(
             )
         }
 
-        fun fromBundle(bundle: Bundle?): PvtArgs {
+        fun fromBundle(bundle: Bundle?): Args {
             if (bundle == null) return default()
 
             val keySet = bundle.keySet()
@@ -75,7 +75,7 @@ internal class PvtArgs(
                 postResponseDelay = bundle.getLong(POST_RESPONSE_DELAY)
             }
 
-            return PvtArgs(
+            return Args(
                     stimulusCount,
                     minInterval,
                     maxInterval,

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtArgs.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtArgs.kt
@@ -1,0 +1,89 @@
+package rs.arthu.androidpvt.lib
+
+import android.os.Bundle
+
+internal class PvtArgs(
+    var stimulusCount: Int = DEFAULT_STIMULUS_COUNT,
+    var minInterval: Long = DEFAULT_MIN_INTERVAL,
+    var maxInterval: Long = DEFAULT_MAX_INTERVAL,
+    var countDownTime: Long = DEFAULT_COUNTDOWN_TIME,
+    var stimulusTimeout: Long = DEFAULT_STIMULUS_TIMEOUT,
+    var postResponseDelay: Long = DEFAULT_POST_RESPONSE_DELAY,
+    ) {
+
+    constructor(
+            stimulusCount: Int? = null,
+            minInterval: Long? = null,
+            maxInterval: Long? = null,
+            countDownTime: Long? = null,
+            stimulusTimeout: Long? = null,
+            postResponseDelay: Long? = null
+    ) : this(
+            stimulusCount ?: DEFAULT_STIMULUS_COUNT,
+            minInterval ?: DEFAULT_MIN_INTERVAL,
+            maxInterval ?: DEFAULT_MAX_INTERVAL,
+            countDownTime ?: DEFAULT_COUNTDOWN_TIME,
+            stimulusTimeout ?: DEFAULT_STIMULUS_TIMEOUT,
+            postResponseDelay ?: DEFAULT_POST_RESPONSE_DELAY
+    )
+
+    companion object {
+        fun default(): PvtArgs {
+            return PvtArgs(
+                    DEFAULT_STIMULUS_COUNT,
+                    DEFAULT_MIN_INTERVAL,
+                    DEFAULT_MAX_INTERVAL,
+                    DEFAULT_COUNTDOWN_TIME,
+                    DEFAULT_STIMULUS_TIMEOUT,
+                    DEFAULT_POST_RESPONSE_DELAY
+            )
+        }
+
+        fun fromBundle(bundle: Bundle?): PvtArgs {
+            if (bundle == null) return default()
+
+            val keySet = bundle.keySet()
+
+            var stimulusCount: Int? = null
+            var minInterval: Long? = null
+            var maxInterval: Long? = null
+            var countDownTime: Long? = null
+            var stimulusTimeout: Long? = null
+            var postResponseDelay: Long? = null
+
+            if (keySet.contains(STIMULUS_COUNT)) {
+                stimulusCount = bundle.getInt(STIMULUS_COUNT)
+            }
+
+            if (keySet.contains(MIN_INTERVAL)) {
+                minInterval = bundle.getLong(MIN_INTERVAL)
+            }
+
+            if (keySet.contains(MAX_INTERVAL)) {
+                maxInterval = bundle.getLong(MAX_INTERVAL)
+            }
+
+            if (keySet.contains(COUNTDOWN_TIME)) {
+                countDownTime = bundle.getLong(COUNTDOWN_TIME)
+            }
+
+            if (keySet.contains(STIMULUS_TIMEOUT)) {
+                stimulusTimeout = bundle.getLong(STIMULUS_TIMEOUT)
+            }
+
+            if (keySet.contains(POST_RESPONSE_DELAY)) {
+                postResponseDelay = bundle.getLong(POST_RESPONSE_DELAY)
+            }
+
+            return PvtArgs(
+                    stimulusCount,
+                    minInterval,
+                    maxInterval,
+                    countDownTime,
+                    stimulusTimeout,
+                    postResponseDelay
+            )
+        }
+    }
+}
+

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtResult.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtResult.kt
@@ -1,0 +1,8 @@
+package rs.arthu.androidpvt.lib
+
+internal data class Result(
+    val testNumber: Int,
+    val timestamp: Long,
+    val interval: Long,
+    val reactionDelay: Long
+)

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtViewModel.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtViewModel.kt
@@ -1,0 +1,20 @@
+package rs.arthu.androidpvt.lib;
+
+import androidx.lifecycle.ViewModel
+
+class PvtViewModel : ViewModel() {
+
+    private lateinit var pvt: Pvt
+
+    init {
+
+
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+
+        pvt.cancel()
+    }
+
+}

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtViewModel.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtViewModel.kt
@@ -3,7 +3,7 @@ package rs.arthu.androidpvt.lib;
 import android.view.MotionEvent
 import androidx.lifecycle.ViewModel
 
-internal class PvtViewModel(args: PvtArgs) : ViewModel(){
+internal class PvtViewModel(args: Args) : ViewModel(){
 
     private var pvt: Pvt = Pvt(args)
 

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtViewModel.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtViewModel.kt
@@ -1,19 +1,11 @@
 package rs.arthu.androidpvt.lib;
 
-import android.os.Bundle
-import android.util.Log
 import android.view.MotionEvent
 import androidx.lifecycle.ViewModel
 
-internal class PvtViewModel(private val args: PvtArgs) : ViewModel(){
+internal class PvtViewModel(args: PvtArgs) : ViewModel(){
 
-    private var pvt: Pvt
-
-    init {
-        Log.d("PvtViewModel", "viewmodel created")
-
-        pvt = Pvt()
-    }
+    private var pvt: Pvt = Pvt(args)
 
     internal fun handleOnTouchEvent(event: MotionEvent?): Boolean {
         if (event?.action == MotionEvent.ACTION_DOWN) {
@@ -26,7 +18,5 @@ internal class PvtViewModel(private val args: PvtArgs) : ViewModel(){
     override fun onCleared() {
         super.onCleared()
         pvt.cancel()
-        Log.d("PvtViewModel", "oncleared")
     }
-
 }

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtViewModel.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtViewModel.kt
@@ -1,13 +1,12 @@
 package rs.arthu.androidpvt.lib;
 
-import android.view.MotionEvent
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 
 internal class PvtViewModel(args: Args) : ViewModel(), Pvt.Listener {
 
-    private var pvt: Pvt = Pvt(args)
+    internal var pvt: Pvt = Pvt(args)
 
     private val _pvtState = MutableLiveData<Pvt.State>()
     val pvtState: LiveData<Pvt.State>
@@ -17,9 +16,9 @@ internal class PvtViewModel(args: Args) : ViewModel(), Pvt.Listener {
     val countdown: LiveData<String>
         get() = _countdown
 
-    private val _reaction = MutableLiveData<String>()
-    val reaction: LiveData<String>
-        get() = _reaction
+    private val _reactionDelay = MutableLiveData<String>()
+    val reactionDelay: LiveData<String>
+        get() = _reactionDelay
 
     private val _results = MutableLiveData<String>()
     val results: LiveData<String>
@@ -27,13 +26,6 @@ internal class PvtViewModel(args: Args) : ViewModel(), Pvt.Listener {
 
     init {
         pvt.setListener(this)
-    }
-
-    internal fun handleOnTouchEvent(event: MotionEvent?): Boolean {
-        if (event?.action == MotionEvent.ACTION_DOWN) {
-            pvt.handleActionDownTouchEvent()
-        }
-        return true
     }
 
     override fun onStateUpdate(newState: Pvt.State) {
@@ -45,7 +37,7 @@ internal class PvtViewModel(args: Args) : ViewModel(), Pvt.Listener {
     }
 
     override fun onReactionDelayUpdate(millisElapsed: Long) {
-        _reaction.value = millisElapsed.toString()
+        _reactionDelay.value = millisElapsed.toString()
     }
 
     override fun onCompleteTest(jsonResults: String) {

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtViewModel.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtViewModel.kt
@@ -1,20 +1,32 @@
 package rs.arthu.androidpvt.lib;
 
+import android.os.Bundle
+import android.util.Log
+import android.view.MotionEvent
 import androidx.lifecycle.ViewModel
 
-class PvtViewModel : ViewModel() {
+internal class PvtViewModel(private val args: PvtArgs) : ViewModel(){
 
-    private lateinit var pvt: Pvt
+    private var pvt: Pvt
 
     init {
+        Log.d("PvtViewModel", "viewmodel created")
 
+        pvt = Pvt()
+    }
 
+    internal fun handleOnTouchEvent(event: MotionEvent?): Boolean {
+        if (event?.action == MotionEvent.ACTION_DOWN) {
+            pvt.handleActionDownTouchEvent()
+        }
+
+        return true
     }
 
     override fun onCleared() {
         super.onCleared()
-
         pvt.cancel()
+        Log.d("PvtViewModel", "oncleared")
     }
 
 }

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtViewModel.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtViewModel.kt
@@ -1,18 +1,55 @@
 package rs.arthu.androidpvt.lib;
 
 import android.view.MotionEvent
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 
-internal class PvtViewModel(args: Args) : ViewModel(){
+internal class PvtViewModel(args: Args) : ViewModel(), Pvt.Listener {
 
     private var pvt: Pvt = Pvt(args)
+
+    private val _pvtState = MutableLiveData<Pvt.State>()
+    val pvtState: LiveData<Pvt.State>
+        get() = _pvtState
+
+    private val _countdown = MutableLiveData<String>()
+    val countdown: LiveData<String>
+        get() = _countdown
+
+    private val _reaction = MutableLiveData<String>()
+    val reaction: LiveData<String>
+        get() = _reaction
+
+    private val _results = MutableLiveData<String>()
+    val results: LiveData<String>
+        get() = _results
+
+    init {
+        pvt.setListener(this)
+    }
 
     internal fun handleOnTouchEvent(event: MotionEvent?): Boolean {
         if (event?.action == MotionEvent.ACTION_DOWN) {
             pvt.handleActionDownTouchEvent()
         }
-
         return true
+    }
+
+    override fun onStateUpdate(newState: Pvt.State) {
+        _pvtState.value = newState
+    }
+
+    override fun onCountdownUpdate(millisElapsed: Long) {
+        _countdown.value = (millisElapsed / 1000).toString()
+    }
+
+    override fun onReactionDelayUpdate(millisElapsed: Long) {
+        _reaction.value = millisElapsed.toString()
+    }
+
+    override fun onCompleteTest(jsonResults: String) {
+        _results.value = jsonResults
     }
 
     override fun onCleared() {

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtViewModelFactory.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtViewModelFactory.kt
@@ -1,0 +1,13 @@
+package rs.arthu.androidpvt.lib
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+
+internal class PvtViewModelFactory(private val args: PvtArgs) : ViewModelProvider.Factory {
+    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(PvtViewModel::class.java)) {
+            return PvtViewModel(args) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtViewModelFactory.kt
+++ b/AndroidPvtLib/src/main/java/rs/arthu/androidpvt/lib/PvtViewModelFactory.kt
@@ -3,7 +3,7 @@ package rs.arthu.androidpvt.lib
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 
-internal class PvtViewModelFactory(private val args: PvtArgs) : ViewModelProvider.Factory {
+internal class PvtViewModelFactory(private val args: Args) : ViewModelProvider.Factory {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(PvtViewModel::class.java)) {
             return PvtViewModel(args) as T

--- a/AndroidPvtLib/src/main/res/layout/activity_pvt.xml
+++ b/AndroidPvtLib/src/main/res/layout/activity_pvt.xml
@@ -25,7 +25,7 @@
         android:padding="16dp"
         android:textSize="10pt"
         android:layout_centerInParent="true"
-        android:text="@string/pvt_instructions" />
+        android:text="@string/instructions" />
 
     <TextView
         android:id="@+id/textViewSub"

--- a/AndroidPvtLib/src/main/res/layout/activity_pvt.xml
+++ b/AndroidPvtLib/src/main/res/layout/activity_pvt.xml
@@ -15,7 +15,7 @@
         android:background="#FF0000" />
 
     <TextView
-        android:id="@+id/textViewMessage"
+        android:id="@+id/textViewMain"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:visibility="visible"
@@ -28,12 +28,12 @@
         android:text="@string/pvt_instructions" />
 
     <TextView
-        android:id="@+id/textViewCountdown"
+        android:id="@+id/textViewSub"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:textColor="@android:color/white"
         android:textAlignment="center"
-        android:layout_below="@+id/textViewMessage"
+        android:layout_below="@+id/textViewMain"
         android:textStyle="bold"
         android:layout_centerInParent="true"
         android:textSize="10pt"

--- a/AndroidPvtLib/src/main/res/values/strings.xml
+++ b/AndroidPvtLib/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="instructions">When a stimulus appears, press on the screen as quickly as you are able. Your response time will then be shown in millseconds.\nTouch  screen to start the test.</string>
+    <string name="instructions">When the display goes RED, press on the screen as quickly as you are able. Your response time will then be shown in millseconds.\nTouch  screen to start the test.</string>
     <string name="ready_message">Prepare to start</string>
     <string name="test_complete">Test complete</string>
     <string name="invalid_reaction">Invalid reaction</string>

--- a/AndroidPvtLib/src/main/res/values/strings.xml
+++ b/AndroidPvtLib/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
-    <string name="pvt_instructions">When each stimulus appears, press anywhere on the screen as fast as you can. Your response time will then be shown in 100ths of a second.\nTouch the screen to start.</string>
-    <string name="ready_message">Get ready to start</string>
+    <string name="pvt_instructions">When a stimulus appears, press on the screen as quickly as you are able. Your response time will then be shown in millseconds.\nTouch  screen to start the test.</string>
+    <string name="ready_message">Prepare to start</string>
     <string name="test_complete">Test complete</string>
     <string name="invalid_reaction">Invalid reaction</string>
     <string name="reaction_delay">%1$dms</string>

--- a/AndroidPvtLib/src/main/res/values/strings.xml
+++ b/AndroidPvtLib/src/main/res/values/strings.xml
@@ -3,5 +3,5 @@
     <string name="ready_message">Prepare to start</string>
     <string name="test_complete">Test complete</string>
     <string name="invalid_reaction">Invalid reaction</string>
-    <string name="reaction_delay">%1$dms</string>
+    <string name="reaction_delay">%1$sms</string>
 </resources>

--- a/AndroidPvtLib/src/main/res/values/strings.xml
+++ b/AndroidPvtLib/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="pvt_instructions">When a stimulus appears, press on the screen as quickly as you are able. Your response time will then be shown in millseconds.\nTouch  screen to start the test.</string>
+    <string name="instructions">When a stimulus appears, press on the screen as quickly as you are able. Your response time will then be shown in millseconds.\nTouch  screen to start the test.</string>
     <string name="ready_message">Prepare to start</string>
     <string name="test_complete">Test complete</string>
     <string name="invalid_reaction">Invalid reaction</string>

--- a/app/src/main/java/rs/arthu/androidpvt/app/MainActivity.kt
+++ b/app/src/main/java/rs/arthu/androidpvt/app/MainActivity.kt
@@ -5,7 +5,6 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
-import rs.arthu.androidpvt.lib.PvtActivity.Companion.NUMBER_OF_STIMULUS_KEY
 import rs.arthu.androidpvt.app.databinding.ActivityMainBinding
 import rs.arthu.androidpvt.lib.PvtActivity
 
@@ -26,9 +25,15 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun startPvtActivity() {
-        val intent = Intent(this, PvtActivity::class.java)
-        intent.putExtra(NUMBER_OF_STIMULUS_KEY, 3)
-        startActivityForResult(intent, PVT_REQUEST)
+        val pvtActivityIntent = PvtActivity.Builder()
+            .withStimulusCount(4)
+            .withCountdownTime(5)
+            .withInterval(2 * 1000, 4 * 1000)
+            .withPostResponseDelay(2 * 1000)
+            .withStimulusTimeout(10 * 1000)
+            .build(this)
+
+        startActivityForResult(pvtActivityIntent, PVT_REQUEST)
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -40,13 +45,10 @@ class MainActivity : AppCompatActivity() {
             PVT_REQUEST -> {
                 data?.getStringExtra(PvtActivity.PVT_RESULTS_KEY)
             }
-            else -> {
-                "No results"
-            }
+            else -> "No results"
         }
 
         Toast.makeText(this, jsonResults, Toast.LENGTH_LONG).show()
-        Log.d(TAG, jsonResults!!)
     }
 
     companion object {

--- a/app/src/main/java/rs/arthu/androidpvt/app/MainActivity.kt
+++ b/app/src/main/java/rs/arthu/androidpvt/app/MainActivity.kt
@@ -27,7 +27,7 @@ class MainActivity : AppCompatActivity() {
     private fun startPvtActivity() {
         val pvtActivityIntent = PvtActivity.Builder()
             .withStimulusCount(4)
-            .withCountdownTime(5)
+            .withCountdownTime(3) 
             .withInterval(2 * 1000, 4 * 1000)
             .withPostResponseDelay(2 * 1000)
             .withStimulusTimeout(10 * 1000)

--- a/app/src/main/java/rs/arthu/androidpvt/app/MainActivity.kt
+++ b/app/src/main/java/rs/arthu/androidpvt/app/MainActivity.kt
@@ -3,9 +3,9 @@ package rs.arthu.androidpvt.app
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import android.util.Log
 import android.widget.Toast
 import rs.arthu.androidpvt.app.databinding.ActivityMainBinding
+import rs.arthu.androidpvt.lib.PVT_RESULTS_KEY
 import rs.arthu.androidpvt.lib.PvtActivity
 
 class MainActivity : AppCompatActivity() {
@@ -27,7 +27,7 @@ class MainActivity : AppCompatActivity() {
     private fun startPvtActivity() {
         val pvtActivityIntent = PvtActivity.Builder()
             .withStimulusCount(4)
-            .withCountdownTime(3) 
+            .withCountdownTime(3)
             .withInterval(2 * 1000, 4 * 1000)
             .withPostResponseDelay(2 * 1000)
             .withStimulusTimeout(10 * 1000)
@@ -43,7 +43,7 @@ class MainActivity : AppCompatActivity() {
 
         val jsonResults: String? = when (requestCode) {
             PVT_REQUEST -> {
-                data?.getStringExtra(PvtActivity.PVT_RESULTS_KEY)
+                data?.getStringExtra(PVT_RESULTS_KEY)
             }
             else -> "No results"
         }

--- a/app/src/main/java/rs/arthu/androidpvt/app/MainActivity.kt
+++ b/app/src/main/java/rs/arthu/androidpvt/app/MainActivity.kt
@@ -26,9 +26,9 @@ class MainActivity : AppCompatActivity() {
 
     private fun startPvtActivity() {
         val pvtActivityIntent = PvtActivity.Builder()
-            .withStimulusCount(4)
-            .withCountdownTime(3)
-            .withInterval(2 * 1000, 4 * 1000)
+            .withStimulusCount(3)
+            .withCountdownTime(3 * 1000) // 3 second countdown
+            .withInterval(2 * 1000, 4 * 1000) // random interval between 2 and 4 seconds duration
             .withPostResponseDelay(2 * 1000)
             .withStimulusTimeout(10 * 1000)
             .build(this)
@@ -51,8 +51,7 @@ class MainActivity : AppCompatActivity() {
         Toast.makeText(this, jsonResults, Toast.LENGTH_LONG).show()
     }
 
-    companion object {
-        private const val TAG = "MainActivity"
+    private companion object {
         private const val PVT_REQUEST = 1
     }
 }


### PR DESCRIPTION
- Including architecture components
- Removing large `PvtListener`, replacing with `Listener` and `StimulusListener` (used to shortcut the ViewModel)
- Creating `PvtViewModel` with observable state, results, reaction delay and countdown
- Creating `PvtViewModelFactory` to pass pvt `Args` to the ViewModel
- Creating `Args` and `fromBundle` method to pass the builder intent data to the ViewModel
- Creating `Builder` class in the pvt activity
- String  content updates
- Better encapsulation